### PR TITLE
Fix bug with custom model output and add test

### DIFF
--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -3,6 +3,7 @@ from torchvision.models import resnet18
 import pytest
 import torch as ch
 from trak.projectors import BasicProjector
+from trak.modelout_functions import ImageClassificationModelOutput
 
 
 @pytest.fixture
@@ -117,3 +118,13 @@ def test_score_finalize(tmp_path):
     traker.start_scoring_checkpoint(ckpt, 0, num_targets=N)
     traker.score(batch, num_samples=N)
     traker.finalize_scores()
+
+
+def test_custom_model_output(tmp_path, cpu_proj):
+    model = resnet18()
+    TRAKer(model=model,
+           task=ImageClassificationModelOutput,
+           save_dir=tmp_path,
+           projector=cpu_proj,
+           train_set_size=20,
+           device='cuda:0')

--- a/trak/traker.py
+++ b/trak/traker.py
@@ -85,10 +85,10 @@ class TRAKer():
         self.load_from_save_dir = load_from_save_dir
 
         if type(self.task) is str:
-            self.modelout_fn = TASK_TO_MODELOUT[(self.task, gradient_computer.is_functional)]
+            self.task = TASK_TO_MODELOUT[(self.task, gradient_computer.is_functional)]
 
         self.gradient_computer = gradient_computer(model=self.model,
-                                                   modelout_fn=self.modelout_fn,
+                                                   modelout_fn=self.task,
                                                    grad_dim=self.num_params)
 
         self.score_computer = BasicScoreComputer(device=self.device)


### PR DESCRIPTION
Due to a typo, any custom model output functions cause an error when initializing the TRAKer. Fix the bug here and add a corresponding test.