### PR TITLE
fixed model output function when computing gradients in float16

### DIFF
--- a/trak/modelout_functions.py
+++ b/trak/modelout_functions.py
@@ -143,7 +143,7 @@ class ImageClassificationModelOutput(AbstractModelOutput):
         cloned_logits = logits.clone()
         # remove the logits of the correct labels from the sum
         # in logsumexp by setting to -ch.inf
-        cloned_logits[bindex, label.unsqueeze(0)] = ch.tensor(-ch.inf).to(logits.device).to(logits.dtype)
+        cloned_logits[bindex, label.unsqueeze(0)] = ch.tensor(-ch.inf, device=logits.device, dtype=logits.dtype)
 
         margins = logits_correct - cloned_logits.logsumexp(dim=-1)
         return margins.sum()

--- a/trak/modelout_functions.py
+++ b/trak/modelout_functions.py
@@ -386,7 +386,7 @@ class TextClassificationModelOutput(AbstractModelOutput):
         logits_correct = logits[bindex, label.unsqueeze(0)]
 
         cloned_logits = logits.clone()
-        cloned_logits[bindex, label.unsqueeze(0)] = ch.tensor(-ch.inf).to(logits.device)
+        cloned_logits[bindex, label.unsqueeze(0)] = ch.tensor(-ch.inf, device=logits.device, dtype=logits.dtype)
 
         margins = logits_correct - cloned_logits.logsumexp(dim=-1)
         return margins.sum()

--- a/trak/modelout_functions.py
+++ b/trak/modelout_functions.py
@@ -143,7 +143,7 @@ class ImageClassificationModelOutput(AbstractModelOutput):
         cloned_logits = logits.clone()
         # remove the logits of the correct labels from the sum
         # in logsumexp by setting to -ch.inf
-        cloned_logits[bindex, label.unsqueeze(0)] = ch.tensor(-ch.inf).to(logits.device)
+        cloned_logits[bindex, label.unsqueeze(0)] = ch.tensor(-ch.inf).to(logits.device).to(logits.dtype)
 
         margins = logits_correct - cloned_logits.logsumexp(dim=-1)
         return margins.sum()


### PR DESCRIPTION
When computing the margins from `image_classification` task, the default dtype of `ch.tensor(-ch.inf)` is float32. This leads to a datatype mismatch if the model gradients and output were computed in float16.