### PR TITLE
[Bug Fix] fix `is_grads_dict` for `IterativeGradientComputer`

### DIFF
--- a/trak/traker.py
+++ b/trak/traker.py
@@ -416,7 +416,7 @@ class TRAKer:
             return 0
 
         grads = self.gradient_computer.compute_per_sample_grad(batch=batch)
-        grads = self.projector.project(grads, model_id=self.saver.current_model_id)
+        grads = self.projector.project(grads, model_id=self.saver.current_model_id, is_grads_dict=isinstance(grads, dict))
         grads /= self.normalize_factor
         self.saver.current_store["grads"][inds] = (
             grads.to(self.dtype).cpu().clone().detach()
@@ -565,7 +565,7 @@ class TRAKer:
 
         grads = self.gradient_computer.compute_per_sample_grad(batch=batch)
 
-        grads = self.projector.project(grads, model_id=self.saver.current_model_id)
+        grads = self.projector.project(grads, model_id=self.saver.current_model_id, is_grads_dict=isinstance(grads, dict))
         grads /= self.normalize_factor
 
         exp_name = self.saver.current_experiment_name


### PR DESCRIPTION
`is_grads_dict` is not set properly, which makes cases where grad is other instance (e.g., tensor) fails.


In `FunctionalGradientComputer`, it may works properly since grads is a dictionary.

https://github.com/MadryLab/trak/blob/39bf22ac0a803dec6dab7f3cd29c168ecdc069a7/trak/gradient_computers.py#L126-L160

While in `IterativeGradientComputer`, the return value could be a tensor.

https://github.com/MadryLab/trak/blob/39bf22ac0a803dec6dab7f3cd29c168ecdc069a7/trak/gradient_computers.py#L215-L237