### PR TITLE
fix finalize features floods CPU memory: remove log and load mapped gradients to device 

### DIFF
--- a/trak/traker.py
+++ b/trak/traker.py
@@ -473,7 +473,7 @@ class TRAKer:
 
             self.saver.load_current_store(model_id)
 
-            g = ch.as_tensor(self.saver.current_store["grads"])
+            g = ch.as_tensor(self.saver.current_store["grads"], device=self.device)
             xtx = self.score_computer.get_xtx(g)
             self.logger.debug(f"XTX is {xtx}")
 

--- a/trak/traker.py
+++ b/trak/traker.py
@@ -475,10 +475,8 @@ class TRAKer:
 
             g = ch.as_tensor(self.saver.current_store["grads"], device=self.device)
             xtx = self.score_computer.get_xtx(g)
-            self.logger.debug(f"XTX is {xtx}")
 
             features = self.score_computer.get_x_xtx_inv(g, xtx)
-            self.logger.debug(f"Features are {features}")
             self.saver.current_store["features"][:] = features.to(self.dtype).cpu()
             if del_grads:
                 self.saver.del_grads(model_id)


### PR DESCRIPTION
loading data directly on device instead of moving from CPU to GPU in score computation steps