### PR TITLE
Fix: Change BERT attention implementation to `eager` in the QNLI example

### DIFF
--- a/examples/qnli.py
+++ b/examples/qnli.py
@@ -55,6 +55,7 @@ class SequenceClassificationModel(nn.Module):
             'bert-base-cased',
             num_labels=2,
             finetuning_task='qnli',
+            attn_implementation='eager',
             cache_dir=None,
             revision='main',
             use_auth_token=None,


### PR DESCRIPTION
The current SDPA mask implementation in Huggingface Transformers includes [data-dependent control flow](https://github.com/huggingface/transformers/blob/3ee24e220863fca88468c1670399eecfe15582c0/src/transformers/modeling_attn_mask_utils.py\#L444), which is not yet supported by [`torch.func.vmap`](https://pytorch.org/docs/stable/func.ux_limitations.html#data-dependent-python-control-flow). Switching to an `eager` implementation enables compatibility with the`FunctionalGradientComputer`.